### PR TITLE
fix the issue that can not install agent to java process from root

### DIFF
--- a/bin/bminstall.sh
+++ b/bin/bminstall.sh
@@ -120,4 +120,12 @@ fi
 # allow for extra java opts via setting BYTEMAN_JAVA_OPTS
 # attach class will validate arguments
 
-java ${BYTEMAN_JAVA_OPTS} -classpath "$CP" org.jboss.byteman.agent.install.Install $*
+USER=`echo "$USER"`
+PID=${*: -1}
+PID_USER="$( ps -o uname= -p "${PID}" )"
+
+if [ "$USER" == "root" ] && [ $JAVA_VERSION -le 8 ]; then
+	sudo -u $PID_USER BYTEMAN_HOME=$BYTEMAN_HOME java ${BYTEMAN_JAVA_OPTS} -classpath "$CP" org.jboss.byteman.agent.install.Install $*
+else
+	java ${BYTEMAN_JAVA_OPTS} -classpath "$CP" org.jboss.byteman.agent.install.Install $*
+fi

--- a/bin/bminstall.sh
+++ b/bin/bminstall.sh
@@ -124,8 +124,8 @@ USER=`echo "$USER"`
 PID=${*: -1}
 PID_USER="$( ps -o uname= -p "${PID}" )"
 
-if [ "$USER" == "root" ] && [ $JAVA_VERSION -le 8 ]; then
-	sudo -u $PID_USER BYTEMAN_HOME=$BYTEMAN_HOME java ${BYTEMAN_JAVA_OPTS} -classpath "$CP" org.jboss.byteman.agent.install.Install $*
+if [ "$USER" == "root" ] && [ "$PID_USER" != "root" ] && [ $JAVA_VERSION -le 8 ]; then
+	sudo -u $PID_USER JAVA_HOME=$JAVA_HOME BYTEMAN_HOME=$BYTEMAN_HOME $JAVA_HOME/bin/java ${BYTEMAN_JAVA_OPTS} -classpath "$CP" org.jboss.byteman.agent.install.Install $*
 else
 	java ${BYTEMAN_JAVA_OPTS} -classpath "$CP" org.jboss.byteman.agent.install.Install $*
 fi


### PR DESCRIPTION
It looks like a bug of java 1.8, need to use the same user to install the agent to the java process.

Signed-off-by: xiang <xiang13225080@163.com>